### PR TITLE
Added default build args 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN /polaris/build/build.sh
 FROM alpine:${ALPINE_VERSION}
 RUN apk -U --no-progress upgrade && \
     apk --no-progress add libgcc sqlite-libs && \
-    install -d -m0755 -o100 -g100 /var/cache/polaris && \
-    install -d -m0755 -o100 -g100 /var/lib/polaris && \
-    install -d -m0755 -o100 -g100 /var/log/polaris && \
+    install -d -m0755 -o1000 -g1000 /var/cache/polaris && \
+    install -d -m0755 -o1000 -g1000 /var/lib/polaris && \
+    install -d -m0755 -o1000 -g1000 /var/log/polaris && \
     rm -f /var/cache/apk/*
 COPY --from=builder /polaris/pkg /
 EXPOSE 5050

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-ARG ALPINE_VERSION
+ARG ALPINE_VERSION=3.18
+ARG POLARIS_VERSION=0.14.0
+ARG USER=1000
+ARG GROUP=1000
 
 FROM alpine:${ALPINE_VERSION} AS builder
-ARG POLARIS_VERSION
 COPY .circleci /polaris/build
+ARG POLARIS_VERSION
 ADD https://github.com/agersant/polaris/releases/download/${POLARIS_VERSION}/Polaris_${POLARIS_VERSION}.tar.gz /polaris/src/polaris.tar.gz
 RUN /polaris/build/build.sh
 
 FROM alpine:${ALPINE_VERSION}
+ARG USER
+ARG GROUP
 RUN apk -U --no-progress upgrade && \
     apk --no-progress add libgcc sqlite-libs && \
-    install -d -m0755 -o1000 -g1000 /var/cache/polaris && \
-    install -d -m0755 -o1000 -g1000 /var/lib/polaris && \
-    install -d -m0755 -o1000 -g1000 /var/log/polaris && \
+    install -d -m0755 -o${USER} -g${GROUP} /var/cache/polaris && \
+    install -d -m0755 -o${USER} -g${GROUP} /var/lib/polaris && \
+    install -d -m0755 -o${USER} -g${GROUP} /var/log/polaris && \
     rm -f /var/cache/apk/*
 COPY --from=builder /polaris/pkg /
 EXPOSE 5050


### PR DESCRIPTION
Added default build args which one would update with new releases etc and added USER & GROUP args which can be specified at build time for easier modification to the owner for music folder.

I set the default UID/GID to the standard for most linux distros first non-root user, but this can ofc be overridden at build time.

( I'm considering whether it would be better to use `lscr.io/linuxserver/alpine-base-image` instead of the standard alpine image as the user and group can be set at runtime with PUID/GUID env variables but that is outside the scope for this pr )

